### PR TITLE
[PS-14125] set broadcast receiver to null after unregistering

### DIFF
--- a/mopub-sdk/mopub-sdk-interstitial/src/main/java/com/skillz/mopub/mobileads/ResponseBodyInterstitial.java
+++ b/mopub-sdk/mopub-sdk-interstitial/src/main/java/com/skillz/mopub/mobileads/ResponseBodyInterstitial.java
@@ -67,6 +67,7 @@ public abstract class ResponseBodyInterstitial extends CustomEventInterstitial {
     public void onInvalidate() {
         if (mBroadcastReceiver != null) {
             mBroadcastReceiver.unregister(mBroadcastReceiver);
+            mBroadcastReceiver = null;
         }
     }
 


### PR DESCRIPTION
set broadcast receiver to null so it doesn't try to unregister again after it already registers.