### PR TITLE
rename groupname in upload script and fix version number

### DIFF
--- a/mopub-sdk/mopub-sdk-base/release.gradle
+++ b/mopub-sdk/mopub-sdk-base/release.gradle
@@ -7,14 +7,14 @@ repositories {
 
 def configurePom(def pom) {
     pom.artifactId = "mopub-sdk-base"
-    pom.name = "com.skillz.mopub"
+    pom.name = "com.skillz-mopub"
     pom.packaging = "aar"
-    pom.version = "5.12.1-skillz"
-    pom.groupId = "com.skillz.mopub"
+    pom.version = "5.12.0-skillz"
+    pom.groupId = "com.skillz-mopub"
     archivesBaseName='mopub-sdk-baseRelease'
 
     pom.project {
-        name "com.skillz.mopub"
+        name "com.skillz-mopub"
 
         description 'MoPub Android SDK - Base'
         url 'https://github.com/skillz/mopub-android-sdk'
@@ -65,8 +65,8 @@ afterEvaluate { project ->
         }
     }
 
-    version = "5.12.1-skillz"
-    group = "com.skillz.mopub"
+    version = "5.12.0-skillz"
+    group = "com.skillz-mopub"
 
     signing {
         required { gradle.taskGraph.hasTask('uploadArchives') }


### PR DESCRIPTION
since we have a new groupname we can have the version number back to where it should be to match the original mopub and the rest of the libs

being com.skillz was interfering with gradles dependency resolution and it was looking for the mopub library in the same place it looks for the other com.skillz stuff (i think) and was causing projects that include skillz to not be able to grab mopub ([more on gradle dependency resolution](https://docs.gradle.org/current/userguide/dependency_resolution.html#obtaining_module_metadata))
